### PR TITLE
Allow annotations in the Certificate types

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -40,10 +40,10 @@ type CertificateEvent struct {
 }
 
 type Certificate struct {
-	ApiVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   map[string]string `json:"metadata"`
-	Spec       CertificateSpec   `json:"spec"`
+	ApiVersion string                 `json:"apiVersion"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       CertificateSpec        `json:"spec"`
 }
 
 type CertificateSpec struct {
@@ -53,10 +53,10 @@ type CertificateSpec struct {
 }
 
 type CertificateList struct {
-	ApiVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Metadata   map[string]string `json:"metadata"`
-	Items      []Certificate     `json:"items"`
+	ApiVersion string                 `json:"apiVersion"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Items      []Certificate          `json:"items"`
 }
 
 type Secret struct {

--- a/processor.go
+++ b/processor.go
@@ -399,7 +399,7 @@ func (p *CertProcessor) deleteCertificate(cert Certificate) error {
 
 func certificateNamespace(c Certificate) string {
 	// Resolve namespace
-	if namespace, ok := c.Metadata["namespace"]; ok {
+	if namespace, ok := c.Metadata["namespace"].(string); ok {
 		return namespace
 	}
 	return "default"


### PR DESCRIPTION
If you use kubectl apply, this sets an annotation, so metadata needs to allow a dictionary of annotations.
At the moment I get:

```
2016/10/03 12:52:48 Error while watching kubernetes events: json: cannot unmarshal object into Go value of type string
2016/10/03 12:52:48 Error while watching kubernetes events: json: cannot unmarshal object into Go value of type string
2016/10/03 12:52:48 Error while watching kubernetes events: json: cannot unmarshal object into Go value of type string
2016/10/03 12:52:48 Error while watching kubernetes events: json: cannot unmarshal object into Go value of type string

```

This is my first time writing Go, so if there's a better way to achieve this I'd appreciate some pointers
