### PR TITLE
Add information and examples RBAC permissions to securely deploy kube-cert-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kube-cert-manager
 kube-cert-manager.exe
+*~

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The code itself however, was entirely reimplemented to use xenolf/lego as the ba
 * [Creating a Certificate](docs/create-a-certificate.md)
 * [Deleting a Certificate](docs/delete-a-certificate.md)
 * [Consuming Certificates](docs/consume-certificates.md)
-- [Managing certificates for Ingress Resources](docs/ingress.md)
-- [Garbage collection of secrets](docs/garbage-collection.md)
+- [Managing Certificates for Ingress Resources](docs/ingress.md)
+- [Garbage Collection of Secrets](docs/garbage-collection.md)
 
 ## Documentation
 
 * [Certificate Third Party Resources](docs/certificate-third-party-resource.md)
 * [Certificate Objects](docs/certificate-objects.md)
-* [Challenge providers](docs/providers.md)
+* [Challenge Providers](docs/providers.md)
 * [Secure Deployment](docs/secure-deployment.md)

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ The code itself however, was entirely reimplemented to use xenolf/lego as the ba
 * [Creating a Certificate](docs/create-a-certificate.md)
 * [Deleting a Certificate](docs/delete-a-certificate.md)
 * [Consuming Certificates](docs/consume-certificates.md)
-- [Managing certificates for Ingress Resources](docs/ingress.md)
-- [Garbage collection of secrets](docs/garbage-collection.md)
+- [Managing Certificates for Ingress Resources](docs/ingress.md)
+- [Garbage Collection of Secrets](docs/garbage-collection.md)
+* [Secure Deployment using RBAC](docs/secure-deployment.md)
 
 ## Documentation
 
 * [Certificate Third Party Resources](docs/certificate-third-party-resource.md)
 * [Certificate Objects](docs/certificate-objects.md)
-* [Challenge providers](docs/providers.md)
+* [Challenge Providers](docs/providers.md)

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The code itself however, was entirely reimplemented to use xenolf/lego as the ba
 * [Consuming Certificates](docs/consume-certificates.md)
 - [Managing Certificates for Ingress Resources](docs/ingress.md)
 - [Garbage Collection of Secrets](docs/garbage-collection.md)
+* [Secure Deployment using RBAC](docs/secure-deployment.md)
 
 ## Documentation
 
 * [Certificate Third Party Resources](docs/certificate-third-party-resource.md)
 * [Certificate Objects](docs/certificate-objects.md)
 * [Challenge Providers](docs/providers.md)
-* [Secure Deployment](docs/secure-deployment.md)

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ The code itself however, was entirely reimplemented to use xenolf/lego as the ba
 * [Certificate Third Party Resources](docs/certificate-third-party-resource.md)
 * [Certificate Objects](docs/certificate-objects.md)
 * [Challenge providers](docs/providers.md)
+* [Secure Deployment](docs/secure-deployment.md)

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -1,0 +1,31 @@
+# Secure deployment of kube-cert-manager using RBAC
+
+Most default kubernetes installs have authorization set to 'AlwaysAllow'.
+This means the 'default' Service Account provided to every container you 
+deploy has 'root' level access to the whole cluster. Containers can enter 
+any other container, including priviledged containers, do and delete 
+anything across the entire cluster. Using an authorisation plug-in is
+prudent. RBAC allow you to manage role-based access as k8s resources.
+
+The [`rbac-example.yaml`](..\k8s\rbac-example.yaml) file contains
+Service Account and a Cluster Role to allow kube-cert-manager
+to manage certificates across the whole cluster
+
+To use this you first need RBAC enabled for your cluster
+  https://kubernetes.io/docs/admin/authorization/
+You might also need some base RBAC roles installed so your cluster
+can operate. Then create the Service Account and roles in [this file](..\k8s\rbac-example.yaml):
+```
+kubectl create -f rbac-example.yaml
+```
+Then add to a `spec.template.spec.serviceAccount` to the deployment:
+```
+serviceAccount: kube-cert-manager
+```
+and deploy the kube-cert-manager as normal.
+Check the kube-cert-manager logs for any permission errors:
+```
+kubectl logs <pod-name> --container kube-cert-manager
+```
+If you are deploying to a different namespace that 'default',
+change the namespaces in `rbac-example.yaml` and in `deployment.yaml`.

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -1,0 +1,35 @@
+# Secure deployment of kube-cert-manager using RBAC
+
+Most default kubernetes installs have authorization set to 'AlwaysAllow'.
+This means the 'default' Service Account provided to every container you 
+deploy has 'root' level access to the whole cluster. Containers can enter 
+any other container, including priviledged containers, do and delete 
+anything across the entire cluster.
+
+Using an authorization plug-in is prudent. RBAC allow you to manage 
+role-based access as kubernetes resources.
+
+The [`rbac-example.yaml`](../k8s/rbac-example.yaml) file contains
+Service Account and a Cluster Role to allow kube-cert-manager
+to manage certificates across the whole cluster
+
+To use this you first need [RBAC enabled for your cluster](https://kubernetes.io/docs/admin/authorization/).
+
+You might also need some base RBAC roles installed so your cluster
+can operate. Then create the Service Account and roles in the [`rbac-example.yaml`](../k8s/rbac-example.yaml) file:
+```
+kubectl create -f rbac-example.yaml
+```
+
+Then add to a `spec.template.spec.serviceAccount` to the deployment:
+```
+serviceAccount: kube-cert-manager
+```
+
+and deploy the kube-cert-manager as normal.
+Check the kube-cert-manager logs for any permission errors:
+```
+kubectl logs <pod-name> --container kube-cert-manager
+```
+If you are deploying to a different namespace that 'default',
+change the namespaces in `rbac-example.yaml` and in `deployment.yaml`.

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -6,18 +6,19 @@ deploy has 'root' level access to the whole cluster. Containers can enter
 any other container, including priviledged containers, do and delete 
 anything across the entire cluster.
 
-Using an authorisation plug-in is prudent. RBAC allow you to manage 
+Using an authorization plug-in is prudent. RBAC allow you to manage 
 role-based access as kubernetes resources.
 
-The [`rbac-example.yaml`](..\k8s\rbac-example.yaml) file contains
+The [`rbac-example.yaml`](../k8s/rbac-example.yaml) file contains
 Service Account and a Cluster Role to allow kube-cert-manager
 to manage certificates across the whole cluster
 
 To use this you first need RBAC enabled for your cluster
+
   https://kubernetes.io/docs/admin/authorization/
 
 You might also need some base RBAC roles installed so your cluster
-can operate. Then create the Service Account and roles in [this file](..\k8s\rbac-example.yaml):
+can operate. Then create the Service Account and roles in [this file](../k8s/rbac-example.yaml):
 ```
 kubectl create -f rbac-example.yaml
 ```

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -16,7 +16,7 @@ to manage certificates across the whole cluster
 To use this you first need [RBAC enabled for your cluster](https://kubernetes.io/docs/admin/authorization/).
 
 You might also need some base RBAC roles installed so your cluster
-can operate. Then create the Service Account and roles in [this file](../k8s/rbac-example.yaml):
+can operate. Then create the Service Account and roles in the [`rbac-example.yaml`](../k8s/rbac-example.yaml) file:
 ```
 kubectl create -f rbac-example.yaml
 ```

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -13,9 +13,7 @@ The [`rbac-example.yaml`](../k8s/rbac-example.yaml) file contains
 Service Account and a Cluster Role to allow kube-cert-manager
 to manage certificates across the whole cluster
 
-To use this you first need RBAC enabled for your cluster
-
-  https://kubernetes.io/docs/admin/authorization/
+To use this you first need [RBAC enabled for your cluster](https://kubernetes.io/docs/admin/authorization/).
 
 You might also need some base RBAC roles installed so your cluster
 can operate. Then create the Service Account and roles in [this file](../k8s/rbac-example.yaml):

--- a/docs/secure-deployment.md
+++ b/docs/secure-deployment.md
@@ -4,8 +4,10 @@ Most default kubernetes installs have authorization set to 'AlwaysAllow'.
 This means the 'default' Service Account provided to every container you 
 deploy has 'root' level access to the whole cluster. Containers can enter 
 any other container, including priviledged containers, do and delete 
-anything across the entire cluster. Using an authorisation plug-in is
-prudent. RBAC allow you to manage role-based access as k8s resources.
+anything across the entire cluster.
+
+Using an authorisation plug-in is prudent. RBAC allow you to manage 
+role-based access as kubernetes resources.
 
 The [`rbac-example.yaml`](..\k8s\rbac-example.yaml) file contains
 Service Account and a Cluster Role to allow kube-cert-manager
@@ -13,15 +15,18 @@ to manage certificates across the whole cluster
 
 To use this you first need RBAC enabled for your cluster
   https://kubernetes.io/docs/admin/authorization/
+
 You might also need some base RBAC roles installed so your cluster
 can operate. Then create the Service Account and roles in [this file](..\k8s\rbac-example.yaml):
 ```
 kubectl create -f rbac-example.yaml
 ```
+
 Then add to a `spec.template.spec.serviceAccount` to the deployment:
 ```
 serviceAccount: kube-cert-manager
 ```
+
 and deploy the kube-cert-manager as normal.
 Check the kube-cert-manager logs for any permission errors:
 ```

--- a/k8s/rbac-example.yaml
+++ b/k8s/rbac-example.yaml
@@ -1,0 +1,58 @@
+#
+# Service Account and Cluster Role to allow kube-cert-manager
+# to manage certificates across the whole cluster
+#
+# Most default kubernetes installs have authorization set to 'AlwaysAllow'.
+# This means the 'default' Service Account provided to every container you 
+# deploy has 'root' level access to the whole cluster. Containers can enter 
+# any other container, including priviledged containers, do and delete 
+# anything across the entire cluster. Using an authorisation plug-in is
+# prudent. RBAC allow you to manage role-based access as k8s resources.
+#
+# To use this you first need RBAC enabled for your cluster
+#   https://kubernetes.io/docs/admin/authorization/
+# You might also need some base RBAC roles installed so your cluster
+# can operate. Then create the Service Account and roles in this file:
+#   kubectl create -f rbac-example.yaml
+# Then add to a spec.template.spec.serviceAccount to the deployment:
+#   serviceAccount: kube-cert-manager
+# and deploy the kube-cert-manager as normal.
+# Check the kube-cert-manager logs for any permission errors:
+#   kubectl logs <pod-name> --container kube-cert-manager
+# If you are deploying to a different namespace that 'default',
+# change the namespaces below and in the Deployment spec.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-cert-manager
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+    name: kube-cert-manager
+rules:
+  - apiGroups: ["*"]
+    resources: ["certificates", "ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "delete"]
+  - apiGroups: ["*"]
+    resources: ["events"]
+    verbs: ["create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: kube-cert-manager-service-account
+subjects:
+  - kind: ServiceAccount
+    namespace: default
+    name: kube-cert-manager
+roleRef:
+  kind: ClusterRole
+  name: kube-cert-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/processor.go
+++ b/processor.go
@@ -72,11 +72,11 @@ func (p *CertProcessor) newACMEClient(acmeUser acme.User, provider string) (*acm
 
 	initDNSProvider := func(p acme.ChallengeProvider, err error) (*acme.Client, *sync.Mutex, error) {
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "Error while initializing provider %v", provider)
+			return nil, nil, errors.Wrapf(err, "Error while initializing challenge provider %v", provider)
 		}
 
 		if err := acmeClient.SetChallengeProvider(acme.DNS01, p); err != nil {
-			return nil, nil, errors.Wrap(err, "Error while setting cloudflare challenge provider")
+			return nil, nil, errors.Wrap(err, "Error while setting challenge provider %v for dns-01", provider)
 		}
 
 		acmeClient.ExcludeChallenges([]acme.Challenge{acme.HTTP01, acme.TLSSNI01})


### PR DESCRIPTION
I prepared and tested these RBAC permissions with kubernetes 1.5.1. There create a Service Account just for kube-cert-manager and grant just enough access to manage certificate, secrets, and ingresses across the cluster. I believe they are about the minimum permissions that kube-cert-manager needs to operate. We could add an example later to restrict access to just one namespace.

Feel free to squash the commits. I made a bunch of markdown tweaks after the original commit.