### PR TITLE
Remove kube-proxy; Fully migrate to client-go v2.0.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4716b0486c4c56cebc177f7f908b22daa9e20addd72cfadc7a999a97ca12ae78
-updated: 2017-04-19T11:25:49.795793226-07:00
+hash: 6ba82c34e9274b01cb90d1ddf27bb3fb4be4bdd7eb5b64542d74e73f95e19957
+updated: 2017-04-20T18:37:10.061567219-05:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -31,17 +31,13 @@ imports:
   - private/signer/v4
   - service/route53
 - name: github.com/boltdb/bolt
-  version: e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
+  version: a705895fdad108f053eae7ee011ed94a0541ee13
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
-- name: github.com/dnsimple/dnsimple-go
-  version: 5a5b427618a76f9eed5ede0f3e6306fbd9311d2e
-  subpackages:
-  - dnsimple
 - name: github.com/docker/distribution
-  version: c3e06c6069653bf72034ed907d6749d3928fdacb
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
   - digest
   - reference
@@ -53,7 +49,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 98c45284d68a05a0e0a576de574bd975946ef9ad
+  version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -73,10 +69,6 @@ imports:
   version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
   subpackages:
   - proto
-- name: github.com/google/go-querystring
-  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
-  subpackages:
-  - query
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/JamesClonk/vultr
@@ -84,7 +76,7 @@ imports:
   subpackages:
   - lib
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailru/easyjson
@@ -94,7 +86,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/miekg/dns
-  version: c862b7e359850847d4945cce311db2ea90cab7c0
+  version: ca336a1f95a6b89be9c250df26c7a41742eb4a6f
 - name: github.com/ovh/go-ovh
   version: d2207178e10e4527e8f222fd8707982df8c3af17
   subpackages:
@@ -102,13 +94,13 @@ imports:
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pkg/errors
-  version: bfd5150e4e41705ded2129ec33379de1cb90b513
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/spf13/pflag
-  version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/timewasted/linode
   version: 37e84520dcf74488f67654f9c775b9752c232dc1
   subpackages:
@@ -117,8 +109,12 @@ imports:
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
+- name: github.com/weppos/dnsimple-go
+  version: 65c1ca73cb19baf0f8b2b33219b7f57595a3ccb0
+  subpackages:
+  - dnsimple
 - name: github.com/xenolf/lego
-  version: 5dfe609afb1ebe9da97c9846d97a55415e5a5ccd
+  version: f5d538caab6dc0c167d4e32990c79bbf9eff578c
   subpackages:
   - acme
   - providers/dns/cloudflare
@@ -136,7 +132,7 @@ imports:
   - providers/dns/route53
   - providers/dns/vultr
 - name: golang.org/x/crypto
-  version: 728b753d0135da6801d45a38e6f43ff55779c5c2
+  version: b8a2a83acfe6e6770b75de42d5ff4c67596675c0
   subpackages:
   - ocsp
 - name: golang.org/x/net
@@ -157,7 +153,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -174,7 +170,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/api
-  version: 1202890e803f07684581b575fda809bf335a533f
+  version: 55146ba61254fdb1c26d65ff3c04bc1611ad73fb
   subpackages:
   - dns/v1
   - gensupport
@@ -195,7 +191,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/ini.v1
-  version: 98c45284d68a05a0e0a576de574bd975946ef9ad
+  version: 766e555c68dc8bda90d197ee8946c37519c19409
 - name: gopkg.in/square/go-jose.v1
   version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
   subpackages:
@@ -204,7 +200,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/client-go
-  version: b22087a53becae45931ed72d5e0f12e0031d771a
+  version: e121606b0d09b2e1c467183ee46217fa85a6b672
   subpackages:
   - pkg/api
   - pkg/api/meta

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,8 +20,9 @@ import:
   - providers/dns/route53
   - providers/dns/vultr
 - package: k8s.io/client-go
-  version: v2.0.0-alpha.0
+  version: v2.0.0
   subpackages:
-  - pkg/api/unversioned
+  - pkg/api
   - pkg/api/v1
   - pkg/apis/extensions/v1beta1
+  - pkg/api/unversioned

--- a/kubectl-proxy/Dockerfile
+++ b/kubectl-proxy/Dockerfile
@@ -1,4 +1,0 @@
-FROM lachlanevenson/k8s-kubectl:v1.4.0
-
-EXPOSE 8001
-CMD ["proxy"]

--- a/kubectl-proxy/build-container.sh
+++ b/kubectl-proxy/build-container.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-docker build -t palmstonegames/kubectl-proxy:1.4.0 -t palmstonegames/kubectl-proxy:latest $(dirname "$0")
-docker push palmstonegames/kubectl-proxy:1.4.0
-docker push palmstonegames/kubectl-proxy:latest

--- a/processor.go
+++ b/processor.go
@@ -265,14 +265,14 @@ func (p *CertProcessor) syncIngresses() error {
 	return nil
 }
 
-func (p *CertProcessor) watchKubernetesEvents(namespace string, labelSelector labels.Selector, wg *sync.WaitGroup, doneChan <-chan struct{}) {
+func (p *CertProcessor) watchKubernetesEvents(namespace string, selector labels.Selector, wg *sync.WaitGroup, doneChan <-chan struct{}) {
 	if namespace == v1.NamespaceAll {
 		log.Printf("Watching certificates and ingresses in all namespaces")
 	} else {
 		log.Printf("Watchining certificates and ingresses in namespace %s", namespace)
 	}
-	certEvents := p.k8s.monitorCertificateEvents(namespace, labelSelector, doneChan)
-	ingressEvents := p.k8s.monitorIngressEvents(namespace, labelSelector, doneChan)
+	certEvents := p.k8s.monitorCertificateEvents(namespace, selector, doneChan)
+	ingressEvents := p.k8s.monitorIngressEvents(namespace, selector, doneChan)
 	for {
 		select {
 		case event := <-certEvents:

--- a/processor.go
+++ b/processor.go
@@ -600,23 +600,6 @@ func (p *CertProcessor) processCertificate(cert Certificate) (processed bool, er
 	return true, nil
 }
 
-func (p *CertProcessor) deleteCertificate(cert Certificate) error {
-	log.Printf("[%v] Deleting user info and certificate details", cert.Spec.Domain)
-	err := p.db.Update(func(tx *bolt.Tx) error {
-		key := []byte(cert.Spec.Domain)
-		tx.Bucket([]byte("user-info")).Delete(key)
-		tx.Bucket([]byte("cert-details")).Delete(key)
-		tx.Bucket([]byte("domain-altnames")).Delete(key)
-		return nil
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "Error while saving data to bolt for domain %v", cert.Spec.Domain)
-	}
-
-	return nil
-}
-
 func (p *CertProcessor) gcSecrets() error {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()

--- a/processor.go
+++ b/processor.go
@@ -42,9 +42,14 @@ import (
 	"github.com/xenolf/lego/providers/dns/rfc2136"
 	"github.com/xenolf/lego/providers/dns/route53"
 	"github.com/xenolf/lego/providers/dns/vultr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/labels"
+	"k8s.io/client-go/pkg/selection"
+	"k8s.io/client-go/rest"
 )
 
 // CertProcessor holds the shared configuration, state, and locks
@@ -61,10 +66,13 @@ type CertProcessor struct {
 	Lock             sync.Mutex
 	HTTPLock         sync.Mutex
 	TLSLock          sync.Mutex
+	k8s              K8sClient
 }
 
 // NewCertProcessor creates and populates a CertProcessor
 func NewCertProcessor(
+	k8s *kubernetes.Clientset,
+	certClient *rest.RESTClient,
 	acmeURL string,
 	certSecretPrefix string,
 	certNamespace string,
@@ -75,6 +83,7 @@ func NewCertProcessor(
 	defaultEmail string,
 	db *bolt.DB) *CertProcessor {
 	return &CertProcessor{
+		k8s:              K8sClient{c: k8s, certClient: certClient},
 		acmeURL:          acmeURL,
 		certSecretPrefix: certSecretPrefix,
 		certNamespace:    certNamespace,
@@ -176,13 +185,13 @@ func (p *CertProcessor) getSecrets() ([]v1.Secret, error) {
 	var secrets []v1.Secret
 	if len(p.namespaces) == 0 {
 		var err error
-		secrets, err = getSecrets(addLabelSelector(p, secretsEndpointAll))
+		secrets, err = p.k8s.getSecrets(v1.NamespaceAll, p.getLabelSelector())
 		if err != nil {
 			return nil, errors.Wrap(err, "Error while fetching secret list")
 		}
 	} else {
 		for _, namespace := range p.namespaces {
-			s, err := getSecrets(addLabelSelector(p, namespacedEndpoint(secretsEndpoint, namespace)))
+			s, err := p.k8s.getSecrets(namespace, p.getLabelSelector())
 			if err != nil {
 				return nil, errors.Wrap(err, "Error while fetching secret list")
 			}
@@ -196,13 +205,13 @@ func (p *CertProcessor) getCertificates() ([]Certificate, error) {
 	var certificates []Certificate
 	if len(p.namespaces) == 0 {
 		var err error
-		certificates, err = getCertificates(addLabelSelector(p, namespacedAllCertEndpoint(certEndpointAll, p.certNamespace)))
+		certificates, err = p.k8s.getCertificates(v1.NamespaceAll, p.getLabelSelector())
 		if err != nil {
 			return nil, errors.Wrap(err, "Error while fetching certificate list")
 		}
 	} else {
 		for _, namespace := range p.namespaces {
-			certs, err := getCertificates(addLabelSelector(p, namespacedCertEndpoint(certEndpoint, p.certNamespace, namespace)))
+			certs, err := p.k8s.getCertificates(namespace, p.getLabelSelector())
 			if err != nil {
 				return nil, errors.Wrap(err, "Error while fetching certificate list")
 			}
@@ -219,13 +228,13 @@ func (p *CertProcessor) getIngresses() ([]v1beta1.Ingress, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating API URL for ingress list")
 		}
-		ingresses, err = getIngresses(addLabelSelector(p, ingressEndpointAll))
+		ingresses, err = p.k8s.getIngresses(v1.NamespaceAll, p.getLabelSelector())
 		if err != nil {
 			return nil, errors.Wrap(err, "Error while fetching ingress list")
 		}
 	} else {
 		for _, namespace := range p.namespaces {
-			igs, err := getIngresses(addLabelSelector(p, namespacedEndpoint(ingressEndpoint, namespace)))
+			igs, err := p.k8s.getIngresses(namespace, p.getLabelSelector())
 			if err != nil {
 				return nil, errors.Wrap(err, "Error while fetching ingress list")
 			}
@@ -256,24 +265,14 @@ func (p *CertProcessor) syncIngresses() error {
 	return nil
 }
 
-func (p *CertProcessor) watchKubernetesEvents(certEndpoint, ingressEndpoint string, wg *sync.WaitGroup, doneChan <-chan struct{}) {
-	log.Printf("Watching %s", certEndpoint)
-	log.Printf("Watching %s", ingressEndpoint)
-	certEvents, certErrs := monitorCertificateEvents(certEndpoint)
-	ingressEvents, ingressErrs := monitorIngressEvents(ingressEndpoint)
-	watchErrs := make(chan error)
-	go func() {
-		for {
-			select {
-			case err := <-certErrs:
-				watchErrs <- err
-			case err := <-ingressErrs:
-				watchErrs <- err
-			case <-doneChan:
-				return
-			}
-		}
-	}()
+func (p *CertProcessor) watchKubernetesEvents(namespace string, labelSelector labels.Selector, wg *sync.WaitGroup, doneChan <-chan struct{}) {
+	if namespace == v1.NamespaceAll {
+		log.Printf("Watching certificates and ingresses in all namespaces")
+	} else {
+		log.Printf("Watchining certificates and ingresses in namespace %s", namespace)
+	}
+	certEvents := p.k8s.monitorCertificateEvents(namespace, labelSelector, doneChan)
+	ingressEvents := p.k8s.monitorIngressEvents(namespace, labelSelector, doneChan)
 	for {
 		select {
 		case event := <-certEvents:
@@ -283,8 +282,6 @@ func (p *CertProcessor) watchKubernetesEvents(certEndpoint, ingressEndpoint stri
 			}
 		case event := <-ingressEvents:
 			p.processIngressEvent(event)
-		case err := <-watchErrs:
-			log.Printf("Error while watching kubernetes events: %v", err)
 		case <-doneChan:
 			wg.Done()
 			log.Println("Stopped certificate event watcher.")
@@ -394,7 +391,7 @@ func (p *CertProcessor) processCertificate(cert Certificate) (processed bool, er
 	namespace := certificateNamespace(cert)
 
 	// Fetch current certificate data from k8s
-	s, err := getSecret(namespace, p.secretName(cert))
+	s, err := p.k8s.getSecret(namespace, p.secretName(cert))
 	if err != nil {
 		return false, errors.Wrapf(err, "Error while fetching certificate acme data for domain %v", cert.Spec.Domain)
 	}
@@ -575,7 +572,7 @@ func (p *CertProcessor) processCertificate(cert Certificate) (processed bool, er
 	}
 
 	// Save the k8s secret
-	if err := saveSecret(namespace, s, isUpdate); err != nil {
+	if err := p.k8s.saveSecret(namespace, s, isUpdate); err != nil {
 		return false, errors.Wrapf(err, "Error while saving secret for domain %v", cert.Spec.Domain)
 	}
 
@@ -583,7 +580,7 @@ func (p *CertProcessor) processCertificate(cert Certificate) (processed bool, er
 	if isUpdate {
 		msg = "Updated certificate"
 	}
-	createEvent(v1.Event{
+	p.k8s.createEvent(v1.Event{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: namespace,
 		},
@@ -644,7 +641,7 @@ func (p *CertProcessor) gcSecrets() error {
 	}
 	usedSecrets := map[string]bool{}
 	for _, cert := range certs {
-		usedSecrets[cert.Namespace+" "+p.secretName(cert)] = true
+		usedSecrets[cert.Metadata.Namespace+" "+p.secretName(cert)] = true
 	}
 	for _, secret := range secrets {
 		// Only check for the deprecated "enabled" annotation if not using the "class" feature
@@ -655,7 +652,7 @@ func (p *CertProcessor) gcSecrets() error {
 			continue
 		}
 		log.Printf("Deleting unused secret %s in namespace %s", secret.Name, secret.Namespace)
-		if err := deleteSecret(secret.Namespace, secret.Name); err != nil {
+		if err := p.k8s.deleteSecret(secret.Namespace, secret.Name); err != nil {
 			return err
 		}
 	}
@@ -691,7 +688,7 @@ func ingressCertificates(p *CertProcessor, ingress v1beta1.Ingress) []Certificat
 				APIVersion: "v1",
 				Kind:       "Certificate",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			Metadata: api.ObjectMeta{
 				Namespace: ingress.Namespace,
 			},
 			Spec: CertificateSpec{
@@ -727,7 +724,7 @@ func (p *CertProcessor) processIngress(ingress v1beta1.Ingress) {
 				APIVersion: "v1",
 				Kind:       "Certificate",
 			},
-			ObjectMeta: v1.ObjectMeta{
+			Metadata: api.ObjectMeta{
 				Namespace: ingress.Namespace,
 			},
 			Spec: CertificateSpec{
@@ -741,7 +738,7 @@ func (p *CertProcessor) processIngress(ingress v1beta1.Ingress) {
 		certs = append(certs, cert)
 	}
 	if len(certs) > 0 && (provider == "" || email == "") {
-		createEvent(v1.Event{
+		p.k8s.createEvent(v1.Event{
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: ingress.Namespace,
 			},
@@ -756,7 +753,7 @@ func (p *CertProcessor) processIngress(ingress v1beta1.Ingress) {
 	for _, cert := range certs {
 		processed, err := p.processCertificate(cert)
 		if err != nil {
-			createEvent(v1.Event{
+			p.k8s.createEvent(v1.Event{
 				ObjectMeta: v1.ObjectMeta{
 					Namespace: ingress.Namespace,
 				},
@@ -769,7 +766,7 @@ func (p *CertProcessor) processIngress(ingress v1beta1.Ingress) {
 			continue
 		}
 		if processed {
-			createEvent(v1.Event{
+			p.k8s.createEvent(v1.Event{
 				ObjectMeta: v1.ObjectMeta{
 					Namespace: ingress.Namespace,
 				},
@@ -784,28 +781,25 @@ func (p *CertProcessor) processIngress(ingress v1beta1.Ingress) {
 }
 
 func certificateNamespace(c Certificate) string {
-	if c.Namespace != "" {
-		return c.Namespace
+	if c.Metadata.Namespace != "" {
+		return c.Metadata.Namespace
 	}
 	return "default"
 }
 
-func addLabelSelector(p *CertProcessor, endpoint string) string {
+func (p *CertProcessor) getLabelSelector() labels.Selector {
 	if p.class != "" {
-		result, err := addURLArgument(endpoint, "labelSelector", createLabelSelector(p))
+		r, err := labels.NewRequirement(
+			addTagPrefix(p.tagPrefix, "class"),
+			selection.Equals,
+			[]string{p.class},
+		)
 		if err != nil {
-			log.Fatalf("Error adding label selector to '%v': %v", endpoint, err)
+			log.Fatalf("unable to create class-equals requirement: %v", err)
 		}
-		return result
+		return labels.NewSelector().Add(*r)
 	}
-	return endpoint
-}
-
-func createLabelSelector(p *CertProcessor) string {
-	if p.class != "" {
-		return addTagPrefix(p.tagPrefix, "class") + "=" + p.class
-	}
-	return ""
+	return nil
 }
 
 func addTagPrefix(prefix, tag string) string {


### PR DESCRIPTION
This isn't fully tested yet and shouldn't be merged quite yet, but I don't know of any specific issues with it.

The TPR certificate watch thingy does seem to work fine, and that was one of the more fiddly bits.

This was a fairly rote translation from the kubectl-proxy requests to proper client requests. I also think that there's room for code-layout / splitting-into-packages / etc improvements, but I'd rather keep this change smaller by avoiding significant refactoring.

Fixes #14.