### PR TITLE
Add pem certificate

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -224,6 +224,7 @@ func (c *ACMECertData) ToSecret(tagPrefix, class string) *v1.Secret {
 	data := make(map[string][]byte)
 	data["tls.crt"] = c.Cert
 	data["tls.key"] = c.PrivateKey
+	data["tls.pem"] = append(c.PrivateKey, c.Cert...)
 
 	return &v1.Secret{
 		TypeMeta: unversioned.TypeMeta{


### PR DESCRIPTION
Hi there, 

Haproxy needs a pem file for certificates.

Also apparently a pem file is a simple concat of the key and the crt ( like in [here ](http://www.loadbalancer.org/blog/client-certificate-authentication-with-haproxy/) )

So I'm making this pr.

cheers :D