### PR TITLE
Add cloudxns and gandiv5 DNS providers

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -29,6 +29,12 @@ See [Using secrets as environment variables](http://kubernetes.io/docs/user-guid
 
 `CLOUDFLARE_API_KEY`: The API key corresponding to the email
 
+### CloudXNS
+
+`CLOUDXNS_API_KEY`: The CloudXNS API key.
+
+`CLOUDXNS_SECRET_KEY`: The CloudXNS Secret key.
+
 ### Digital Ocean
 
 `DO_AUTH_TOKEN`: The digital ocean authorization token
@@ -58,6 +64,10 @@ See [Using secrets as environment variables](http://kubernetes.io/docs/user-guid
 ### Gandi
 
 `GANDI_API_KEY`: The API key for Gandi
+
+### Gandi V5
+
+`GANDIV5_API_KEY`: The API key for Gandi's V5 API. 
 
 ### Google Cloud
 

--- a/glide.lock
+++ b/glide.lock
@@ -156,17 +156,19 @@ imports:
   subpackages:
   - codec
 - name: github.com/xenolf/lego
-  version: addee401b08f55d8b86532325d112e1fdd76bef6
+  version: 06a8e7c475c03ef8d4773284ac63357d2810601b
   subpackages:
   - acme
   - providers/dns/azure
   - providers/dns/cloudflare
+  - providers/dns/cloudxns
   - providers/dns/digitalocean
   - providers/dns/dnsimple
   - providers/dns/dnsmadeeasy
   - providers/dns/dnspod
   - providers/dns/dyn
   - providers/dns/gandi
+  - providers/dns/gandiv5
   - providers/dns/googlecloud
   - providers/dns/linode
   - providers/dns/namecheap

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,16 +3,18 @@ import:
 - package: github.com/boltdb/bolt
 - package: github.com/pkg/errors
 - package: github.com/xenolf/lego
-  version: addee401b08f55d8b86532325d112e1fdd76bef6
+  version: 06a8e7c475c03ef8d4773284ac63357d2810601b
   subpackages:
   - acme
   - providers/dns/cloudflare
+  - providers/dns/cloudxns
   - providers/dns/digitalocean
   - providers/dns/dnsimple
   - providers/dns/dnsmadeeasy
   - providers/dns/dnspod
   - providers/dns/dyn
   - providers/dns/gandi
+  - providers/dns/gandiv5
   - providers/dns/googlecloud
   - providers/dns/linode
   - providers/dns/namecheap

--- a/processor.go
+++ b/processor.go
@@ -30,12 +30,14 @@ import (
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/providers/dns/azure"
 	"github.com/xenolf/lego/providers/dns/cloudflare"
+	"github.com/xenolf/lego/providers/dns/cloudxns"
 	"github.com/xenolf/lego/providers/dns/digitalocean"
 	"github.com/xenolf/lego/providers/dns/dnsimple"
 	"github.com/xenolf/lego/providers/dns/dnsmadeeasy"
 	"github.com/xenolf/lego/providers/dns/dnspod"
 	"github.com/xenolf/lego/providers/dns/dyn"
 	"github.com/xenolf/lego/providers/dns/gandi"
+	"github.com/xenolf/lego/providers/dns/gandiv5"
 	"github.com/xenolf/lego/providers/dns/googlecloud"
 	"github.com/xenolf/lego/providers/dns/linode"
 	"github.com/xenolf/lego/providers/dns/namecheap"
@@ -133,6 +135,8 @@ func (p *CertProcessor) newACMEClient(acmeUser acme.User, provider string) (*acm
 		return initDNSProvider(azure.NewDNSProvider())
 	case "cloudflare":
 		return initDNSProvider(cloudflare.NewDNSProvider())
+	case "cloudxns":
+		return initDNSProvider(cloudxns.NewDNSProvider())
 	case "digitalocean":
 		return initDNSProvider(digitalocean.NewDNSProvider())
 	case "dnsimple":
@@ -145,6 +149,8 @@ func (p *CertProcessor) newACMEClient(acmeUser acme.User, provider string) (*acm
 		return initDNSProvider(dyn.NewDNSProvider())
 	case "gandi":
 		return initDNSProvider(gandi.NewDNSProvider())
+	case "gandiv5":
+		return initDNSProvider(gandiv5.NewDNSProvider())
 	case "googlecloud":
 		return initDNSProvider(googlecloud.NewDNSProvider())
 	case "linode":


### PR DESCRIPTION
Gandi's old API no longer works. This updates xenolf/lego to a version that works with cloudxns and gandi's v5 API.